### PR TITLE
Fix module prefix's

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # CRNN Receipt Scanner
-A machine learning implementation of OCR  
+A machine learning implementation of OCR
 [Project report of original authors](project_report.pdf)
 
 > ### Development Environment
 > Python 3+
 
 > ### Installation:
-> Clone Repository  
+> Clone Repository
 > original: `git clone https://github.com/billstark/receipt-scanner`
 >
 > modified: `git clone https://github.com/sandeepkundala/receipt-scanner`
->  
-> In repository root directory:  
+>
+> In repository root directory:
 > `pip install -r requirements.txt`
 
 > ### Usage:
-> In repository root directory:  
-> `python crnn_processor.py --image [IMAGE_PATH]`
+> In repository root directory:
+> `python crnn_processor.py --img [IMAGE_PATH]`

--- a/ReceiptGenerator/letter_cutter.py
+++ b/ReceiptGenerator/letter_cutter.py
@@ -2,8 +2,8 @@ import numpy as np
 import cv2
 import os
 import sys
-from bounding_box import BoundingBox
-from utils import normalized_avg
+from ReceiptGenerator.bounding_box import BoundingBox
+from ReceiptGenerator.utils import normalized_avg
 
 def merge_bounding_boxes(bounding_boxes):
     # Algo to be improved for better performance

--- a/ReceiptGenerator/line_seg.py
+++ b/ReceiptGenerator/line_seg.py
@@ -1,8 +1,8 @@
 import cv2
 import numpy as np
 import os
-from bounding_box import BoundingBox
-from utils import normalized_avg
+from ReceiptGenerator.bounding_box import BoundingBox
+from ReceiptGenerator.utils import normalized_avg
 
 def eval_line_height(bounding_boxes):
     heights = [box.h for box in bounding_boxes]


### PR DESCRIPTION
This patch makes 2 small tweaks, which will hopefully make the repo easier for users to try out ;)

1. Correctly import `ReceiptGenerator.bounding_box` and `ReceiptGenerator.utils`
2. Correctly document the image flag. (--img, not --image)

This PR addresses issue https://github.com/billstark/receipt-scanner/issues/12