### PR TITLE
Use tensorflow 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A machine learning implementation of OCR
 [Project report of original authors](project_report.pdf)
 
 > ### Development Environment
-> Python 3+
+> Python 3.5.x - 3.7.12
 
 > ### Installation:
 > Clone Repository

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
-opencv-python
+opencv-python>3.4.0.14<5.0.0
 augmentor
 pillow
-tensorflow_gpu==1.1.0
-numpy==1.13.1
-opencv_python==3.2.0.7
-matplotlib==2.0.2
-easydict==1.6
-tensorflow>=1.12.1
+tensorflow_gpu==1.13.1
+numpy==1.17
+matplotlib
+easydict
+tensorflow==1.13.1


### PR DESCRIPTION
This patch upgrades tensorflow from `>=1.12.1` to `==1.13.1`. The codebase is written assuming tensorflow `1.x.x`, Which is why it's better to pin tensorflow to a known working version.

We also set constraints for opencv-python to ensure we get a wheel package for python 3.5.

Numpy needed to be upgraded because bumping tensorflow required a newer version of numpym from what I can tell this upgrade doesn't cause any issues.

`tensorflow_gpu` is upgraded to match `tensorflow`

Because this codebase is written assuming `tensorflow 1.x.x`, and the latest python version that supports `tensorflow 1.x.x` is `python 3.7.12`, we constrain the python versions to 3.5.x - 3.7.12.